### PR TITLE
Fixed the applied_operations will cast to a "dict"

### DIFF
--- a/monai/data/utils.py
+++ b/monai/data/utils.py
@@ -618,7 +618,7 @@ def decollate_batch(batch, detach: bool = True, pad=True, fill_value=None):
                     t.is_batch = False
             for t, m in zip(out_list, batch.applied_operations):
                 if isinstance(t, MetaObj):
-                    t.applied_operations = m
+                    t.applied_operations.append(m)
                     t.is_batch = False
         if out_list[0].ndim == 0 and detach:
             return [t.item() for t in out_list]


### PR DESCRIPTION
…nvoke the decollate_batch function

Fixed the applied_operations cast from type "list" to a "dict" when invoke the decollate_batch function. When decollate_batch applied to a <MetaTensor> object, the original codes will replace the meta information(see line 621), which would break the design: type of the "applied_operations" is a list.

Fixes # .

### Description

A few sentences describing the changes proposed in this pull request.

### Types of changes
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Non-breaking change (fix or new feature that would not break existing functionality).
- [ ] Breaking change (fix or new feature that would cause existing functionality to change).
- [ ] New tests added to cover the changes.
- [ ] Integration tests passed locally by running `./runtests.sh -f -u --net --coverage`.
- [ ] Quick tests passed locally by running `./runtests.sh --quick --unittests  --disttests`.
- [ ] In-line docstrings updated.
- [ ] Documentation updated, tested `make html` command in the `docs/` folder.
